### PR TITLE
Changed to use puppetlabs powershell

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,8 +37,8 @@
   },
   "dependencies": [
     {
-      "name": "joshcooper/powershell",
-      "version_requirement": ">=0.0.6"
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">=1.0.2"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Use of puppet labs powershell preferred option, puppet powershelgl is supported under enterprise
