### PR TITLE
The type() function is deprecated in Puppet 4.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class windows_ad (
     anchor{'windows_ad::begin':} -> Windows_ad::Organisationalunit <| |> -> Windows_ad::Group <| |> -> Windows_ad::User <| |> -> Windows_ad::Groupmembers <| |> -> anchor{'windows_ad::end':}
   }
 
-  if type($groups_hiera_merge) == 'string' {
+  if type3x($groups_hiera_merge) == 'string' {
     $groups_hiera_merge_real = str2bool($groups_hiera_merge)
   } else {
     $groups_hiera_merge_real = $groups_hiera_merge
@@ -130,7 +130,7 @@ class windows_ad (
     create_resources('windows_ad::group',$groups_real)
   }
 
-  if type($users_hiera_merge) == 'string' {
+  if type3x($users_hiera_merge) == 'string' {
     $users_hiera_merge_real = str2bool($users_hiera_merge)
   } else {
     $users_hiera_merge_real = $users_hiera_merge
@@ -147,7 +147,7 @@ class windows_ad (
     create_resources('windows_ad::user',$users_real)
   }
 
-  if type($usersingroup_hiera_merge) == 'string' {
+  if type3x($usersingroup_hiera_merge) == 'string' {
     $usersingroup_hiera_merge_real = str2bool($usersingroup_hiera_merge)
   } else {
     $usersingroup_hiera_merge_real = $usersingroup_hiera_merge


### PR DESCRIPTION
This substitutes the type3x() function in stdlib, which is intended for
backward compatability with Puppet 3.
